### PR TITLE
[18.0][FIX] point_of_sale: incorrect method signature

### DIFF
--- a/addons/point_of_sale/models/ir_module_module.py
+++ b/addons/point_of_sale/models/ir_module_module.py
@@ -5,17 +5,17 @@ class IrModuleModule(models.Model):
     _inherit = 'ir.module.module'
 
     @api.model
-    def _load_pos_data_fields(self):
+    def _load_pos_data_fields(self, config_id):
         return ['id', 'name', 'state']
 
     @api.model
-    def _load_pos_data_domain(self):
+    def _load_pos_data_domain(self, data):
         return [('name', '=', 'pos_settle_due')]
 
     def _load_pos_data(self, data):
-        domain = self._load_pos_data_domain()
-        fields = self._load_pos_data_fields()
+        domain = self._load_pos_data_domain(data)
+        fields = self._load_pos_data_fields(data['pos.config']['data'][0]['id'])
         return {
             'data': self.search_read(domain, fields, load=False),
-            'fields': self._load_pos_data_fields(),
+            'fields': self._load_pos_data_fields(data['pos.config']['data'][0]['id']),
         }

--- a/doc/cla/individual/yotsubasuzu.md
+++ b/doc/cla/individual/yotsubasuzu.md
@@ -1,0 +1,11 @@
+Vietnam, 2025-07-17
+
+I hereby agree to the terms of the Odoo Individual Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Nguyen Ngoc Linh nguyenlinh125891@gmail.com https://github.com/yotsubasuzu


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**
The method was first introduce from this PR https://github.com/odoo/odoo/pull/183540.
In [pos.session.load_data](https://github.com/odoo/odoo/blob/18.0/addons/point_of_sale/models/pos_session.py#L185), a fallback method call inside the except AccessError block may raise a TypeError.
This occurs if the user lacks read access to the ir.module.module model, which normally should be granted by the base.group_user group when the base_install_request module is auto-installed.
If the module is not installed, access rights are missing, leading to an unintended method signature mismatch.

**Current behavior before PR:**
- If `base_install_request` is not installed, `base.group_user` users may not have read access to `ir.module.module`.
- The `AccessError` is correctly caught, but the fallback method call includes an argument not expected by the method, leading to a `TypeError`.

**Desired behavior after PR is merged:**
- The fallback method call is updated to match the expected signature.
- The `TypeError` is avoided even when access to `ir.module.module` is restricted due to missing `base_install_request`.



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
