### PR TITLE
[18.0][FIX] point_of_sale: Grant base.group_user read access to ir.module.module

### DIFF
--- a/addons/point_of_sale/models/ir_module_module.py
+++ b/addons/point_of_sale/models/ir_module_module.py
@@ -16,6 +16,6 @@ class IrModuleModule(models.Model):
         domain = self._load_pos_data_domain()
         fields = self._load_pos_data_fields()
         return {
-            'data': self.search_read(domain, fields, load=False),
+            'data': self.sudo().search_read(domain, fields, load=False),
             'fields': self._load_pos_data_fields(),
         }


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**
In the repository OCA/POS PR `test with OCB` have been failing since PR#1301 `https://github.com/OCA/OCB/pull/1301` was merged.
You can see an example of the failing test here: [`https://github.com/OCA/pos/actions/runs/16340188713/job/46160658528?pr=1406#step:8:147`].
The failures occur because PR#1301 disables the `base_install_request` auto-install mechanism, which previously granted implicit read access to the `ir.module.module` model for users in the `base.group_user` group. With that mechanism turned off, these users now receive an `AccessError` when attempting to read `ir.module.module` in code paths such as:

pos.session.load_data `https://github.com/odoo/odoo/blob/18.0/addons/point_of_sale/models/pos_session.py#L185`

**Desired behavior after PR is merged:**
This PR adds the missing explicit read access to the `ir.module.module` model for `base.group_user`, resolving the `AccessError` and restoring correct behavior for non-admin users in affected code paths.

**Related Works**
In parallel, I have submitted PR#219367 to the Odoo main repository (`https://github.com/odoo/odoo/pull/219367`) to address issues with incorrect method signatures in the same context.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
